### PR TITLE
add provenance flag to npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
 
       - run: yarn install --immutable
       - run: yarn build
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<img width="836" height="185" alt="image" src="https://github.com/user-attachments/assets/9e855253-5b8d-46ba-b62c-a327bb0c049d" />

https://docs.npmjs.com/cli/v11/commands/npm-publish#provenance