### PR TITLE
update avalara-product cache ttl

### DIFF
--- a/src/modules/avalara-product/service.ts
+++ b/src/modules/avalara-product/service.ts
@@ -29,7 +29,7 @@ export class AvalaraProductModuleService extends MedusaService({
 
   private readonly FEED_BATCH_SIZE = 1000;
   private readonly MAX_FEED_ITERATIONS = 1000; // max 1,000,000 records - to prevent infinite loops
-  private readonly CACHE_TTL = 10 * 365 * 24 * 60 * 60; // 10 years - `cache` requires TTL (-1 is invalid, 0 immediate expiry)
+  private readonly CACHE_TTL = 30 * 24 * 60 * 60; // 30 days - `cache` requires TTL (-1 is invalid, 0 immediate expiry)
 
   constructor(container: InjectedDependencies) {
     super(container);


### PR DESCRIPTION
10 years works for Redis but leads to some issues when the default cache provider is used. Therefore, we need to decrease the cache TTL value and feed cache by a job: https://github.com/u11d-com/medusa-avalara/issues/14