### PR TITLE
pass integration identifier information

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ Access your Avalara dashboard to obtain the required credentials:
 | `environment`              | `"sandbox" \| "production"` | ✅       | -       | AvaTax environment                                                                                                       |
 | `companyCode`              | `string`                    | ✅       | -       | Your company code in AvaTax                                                                                              |
 | `documentRecordingEnabled` | `boolean`                   | ❌       | `true`  | Controls whether documents should be recorded in AvaTax. If set to `false` transactions (sales invoices) are not created |
-| `appName`                  | `string`                    | ❌       | -       | Custom app name                                                                                                          |
-| `appVersion`               | `string`                    | ❌       | -       | Custom app version                                                                                                       |
 | `machineName`              | `string`                    | ❌       | -       | Machine identifier                                                                                                       |
 
 ### Ship From Address (`shipFromAddress`)

--- a/src/services/avatax-client.ts
+++ b/src/services/avatax-client.ts
@@ -2,21 +2,24 @@ import AvaTaxClient from "avatax";
 import { LogLevel } from "avatax/lib/utils/logger";
 import { Logger } from "@medusajs/framework/types";
 import { AvataxClientOptions } from "../types";
+import { getPackageVersion } from "../utils";
 
 export class AvataxClientFactory {
   private client: AvaTaxClient;
+  private readonly pluginVersion: string;
 
   constructor(
     private readonly logger: Logger,
     private readonly options: AvataxClientOptions
   ) {
+    this.pluginVersion = getPackageVersion(this.logger);
     this.initializeClient();
   }
 
   private initializeClient(): void {
     this.client = new AvaTaxClient({
-      appName: this.options.appName || "MedusaAvaTaxPlugin",
-      appVersion: this.options.appVersion || "1.0.0",
+      appName: "MedusaByU11D;a0oUz000009NbjFIAS",
+      appVersion: this.pluginVersion,
       machineName: this.options.machineName || "MedusaServer",
       environment: this.options.environment,
       timeout: 30_000,

--- a/src/services/avatax-options-validator.ts
+++ b/src/services/avatax-options-validator.ts
@@ -57,8 +57,6 @@ export class AvataxOptionsValidator {
       "production",
     ]);
 
-    this.validateOptionalField("appName", clientOptions);
-    this.validateOptionalField("appVersion", clientOptions);
     this.validateOptionalField("machineName", clientOptions);
 
     return true;

--- a/src/types/avatax-client-options.ts
+++ b/src/types/avatax-client-options.ts
@@ -1,6 +1,4 @@
 export type AvataxClientOptions = {
-  appName?: string;
-  appVersion?: string;
   machineName?: string;
   accountId: string;
   licenseKey: string;

--- a/src/utils/get-package-version.ts
+++ b/src/utils/get-package-version.ts
@@ -1,0 +1,24 @@
+import { Logger } from "@medusajs/framework/types";
+
+const npmPackagePath = "../../package.json";
+const localLinkPackagePath = "../../../../package.json";
+
+export const getPackageVersion = (logger: Logger): string => {
+  let version: string = "";
+
+  logger.debug("Loading package version...");
+  [npmPackagePath, localLinkPackagePath].forEach((path) => {
+    try {
+      const packageJson = require(path);
+      version = packageJson.version;
+    } catch (error) {}
+  });
+
+  if (version) {
+    logger.debug(`Avalara plugin package version found: ${version}`);
+    return version;
+  } else {
+    logger.warn("Avalara plugin package version not found in any known paths");
+    return "0.0.0";
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./get-avalara-customer-cache-key";
 export * from "./get-avalara-product-cache-key";
 export * from "./get-avalara-tax-included-cache-key";
+export * from "./get-package-version";
 export * from "./is-valid-entity-use-code";
 export * from "./log-workflow-results";
 export * from "./with-avalara-plugin";


### PR DESCRIPTION
Avalara needs to know where API requests come from. For this purpose, our integration received unique identifier which should be included in each HTTP request. In fact we need to set `X-Avalara Client ID` header and it's handled in this PR. Additionally, this PR includes plugin version.

Learn more how the header is prepared here: https://github.com/avadev/AvaTax-REST-V2-JS-SDK/blob/main/lib/AvaTaxClient.ts