### PR TITLE
fix: void transactions with DocVoided so AvaTax actually cancels them

### DIFF
--- a/src/workflows/void-avalara-transaction.ts
+++ b/src/workflows/void-avalara-transaction.ts
@@ -37,7 +37,7 @@ const voidAvalaraTransactionStep = createStep(
       await client.voidTransaction({
         companyCode,
         model: {
-          code: VoidReasonCode.Unspecified,
+          code: VoidReasonCode.DocVoided,
         },
         transactionCode: orderId,
         documentType: DocumentType.SalesInvoice,


### PR DESCRIPTION
Fixes #71.

`VoidReasonCode.Unspecified` is accepted by the AvaTax API (HTTP 200) but performs no state change for the void operation — the document stays `Saved`, so cancelled Medusa orders keep live tax documents on the books while the plugin logs "Successfully voided".

`DocVoided` is the reason code that actually cancels a document. Verified against the AvaTax sandbox: voiding a `Saved` Sales Invoice with `Unspecified` leaves it `Saved`; the identical call with `DocVoided` returns the document as `Cancelled`.

One-line change, no API-surface impact. Thanks for the plugin — it's been solid otherwise; happy to adjust anything about this PR.